### PR TITLE
[FEAT]: 프로필 이미지 변경 및 삭제 API

### DIFF
--- a/src/main/java/the_t/mainproject/domain/member/application/MemberService.java
+++ b/src/main/java/the_t/mainproject/domain/member/application/MemberService.java
@@ -1,0 +1,10 @@
+package the_t.mainproject.domain.member.application;
+
+import the_t.mainproject.global.common.Message;
+import the_t.mainproject.global.common.SuccessResponse;
+import the_t.mainproject.global.security.UserDetailsImpl;
+
+public interface MemberService {
+
+    SuccessResponse<Message> modifyProfileImage(UserDetailsImpl userDetails, String profile_image);
+}

--- a/src/main/java/the_t/mainproject/domain/member/application/MemberService.java
+++ b/src/main/java/the_t/mainproject/domain/member/application/MemberService.java
@@ -7,4 +7,6 @@ import the_t.mainproject.global.security.UserDetailsImpl;
 public interface MemberService {
 
     SuccessResponse<Message> modifyProfileImage(UserDetailsImpl userDetails, String profile_image);
+
+    SuccessResponse<Message> deleteProfileImage(UserDetailsImpl userDetails);
 }

--- a/src/main/java/the_t/mainproject/domain/member/application/MemberServiceImpl.java
+++ b/src/main/java/the_t/mainproject/domain/member/application/MemberServiceImpl.java
@@ -1,0 +1,34 @@
+package the_t.mainproject.domain.member.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import the_t.mainproject.domain.member.domain.Member;
+import the_t.mainproject.domain.member.domain.repository.MemberRepository;
+import the_t.mainproject.global.common.Message;
+import the_t.mainproject.global.common.SuccessResponse;
+import the_t.mainproject.global.security.UserDetailsImpl;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class MemberServiceImpl implements MemberService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    @Transactional
+    public SuccessResponse<Message> modifyProfileImage(UserDetailsImpl userDetails, String profile_image) {
+        Member member = memberRepository.findById(userDetails.getMember().getId())
+                .orElseThrow(() -> new BadCredentialsException("잘못된 토큰 입력입니다."));
+
+        member.updateProfileImage(profile_image);
+
+        Message message = Message.builder()
+                .message("프로필 이미지 설정이 변경되었습니다.")
+                .build();
+
+        return SuccessResponse.of(message);
+    }
+}

--- a/src/main/java/the_t/mainproject/domain/member/application/MemberServiceImpl.java
+++ b/src/main/java/the_t/mainproject/domain/member/application/MemberServiceImpl.java
@@ -31,4 +31,19 @@ public class MemberServiceImpl implements MemberService {
 
         return SuccessResponse.of(message);
     }
+
+    @Override
+    @Transactional
+    public SuccessResponse<Message> deleteProfileImage(UserDetailsImpl userDetails) {
+        Member member = memberRepository.findById(userDetails.getMember().getId())
+                .orElseThrow(() -> new BadCredentialsException("잘못된 토큰 입력입니다."));
+
+        member.updateProfileImage(null);
+
+        Message message = Message.builder()
+                .message("프로필 이미지 삭제가 완료되었습니다.")
+                .build();
+
+        return SuccessResponse.of(message);
+    }
 }

--- a/src/main/java/the_t/mainproject/domain/member/domain/Member.java
+++ b/src/main/java/the_t/mainproject/domain/member/domain/Member.java
@@ -41,4 +41,8 @@ public class Member extends BaseEntity {
     public void updatePassword(String password) {
         this.password = password;
     }
+
+    public void updateProfileImage(String profileImage) {
+        this.profileImage = profileImage;
+    }
 }

--- a/src/main/java/the_t/mainproject/domain/member/presentation/MemberController.java
+++ b/src/main/java/the_t/mainproject/domain/member/presentation/MemberController.java
@@ -1,0 +1,27 @@
+package the_t.mainproject.domain.member.presentation;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import the_t.mainproject.domain.member.application.MemberServiceImpl;
+import the_t.mainproject.global.common.Message;
+import the_t.mainproject.global.common.SuccessResponse;
+import the_t.mainproject.global.security.UserDetailsImpl;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/members")
+public class MemberController {
+
+    private final MemberServiceImpl memberService;
+
+    @Operation(summary = "프로필 이미지 수정")
+    @PutMapping("/image")
+    public ResponseEntity<SuccessResponse<Message>> modifyProfileImage(@AuthenticationPrincipal UserDetailsImpl userDetails, String profile_image) {
+        return ResponseEntity.ok(memberService.modifyProfileImage(userDetails, profile_image));
+    }
+}

--- a/src/main/java/the_t/mainproject/domain/member/presentation/MemberController.java
+++ b/src/main/java/the_t/mainproject/domain/member/presentation/MemberController.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -21,7 +22,13 @@ public class MemberController {
 
     @Operation(summary = "프로필 이미지 수정")
     @PutMapping("/image")
-    public ResponseEntity<SuccessResponse<Message>> modifyProfileImage(@AuthenticationPrincipal UserDetailsImpl userDetails, String profile_image) {
-        return ResponseEntity.ok(memberService.modifyProfileImage(userDetails, profile_image));
+    public ResponseEntity<SuccessResponse<Message>> modifyProfileImage(@AuthenticationPrincipal UserDetailsImpl member, String profile_image) {
+        return ResponseEntity.ok(memberService.modifyProfileImage(member, profile_image));
+    }
+
+    @Operation(summary = "프로필 이미지 삭제")
+    @DeleteMapping("/image")
+    public ResponseEntity<SuccessResponse<Message>> deleteProfileImage(@AuthenticationPrincipal UserDetailsImpl member) {
+        return ResponseEntity.ok(memberService.deleteProfileImage(member));
     }
 }

--- a/src/main/java/the_t/mainproject/global/config/SecurityConfig.java
+++ b/src/main/java/the_t/mainproject/global/config/SecurityConfig.java
@@ -38,7 +38,8 @@ public class SecurityConfig {
             "/auth/**",
             "/test",
             "/post/**",
-            "/mails/**"
+            "/mails/**",
+            "/members/**"
     };
 
     @Bean

--- a/src/main/java/the_t/mainproject/global/security/UserDetailsImpl.java
+++ b/src/main/java/the_t/mainproject/global/security/UserDetailsImpl.java
@@ -11,7 +11,13 @@ public class UserDetailsImpl implements UserDetails {
 
     private final Member member;
 
-    public UserDetailsImpl(Member member) { this.member = member; }
+    public UserDetailsImpl(Member member) {
+        this.member = member;
+    }
+
+    public Member getMember() {
+        return member;
+    }
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
@@ -20,20 +26,32 @@ public class UserDetailsImpl implements UserDetails {
     }
 
     @Override
-    public String getPassword() { return member.getPassword(); }
+    public String getPassword() {
+        return member.getPassword();
+    }
 
     @Override
-    public String getUsername() { return member.getEmail(); }
+    public String getUsername() {
+        return member.getEmail();
+    }
 
     @Override
-    public boolean isAccountNonExpired() { return true; }
+    public boolean isAccountNonExpired() {
+        return true;
+    }
 
     @Override
-    public boolean isAccountNonLocked() { return true; }
+    public boolean isAccountNonLocked() {
+        return true;
+    }
 
     @Override
-    public boolean isCredentialsNonExpired() { return true; }
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
 
     @Override
-    public boolean isEnabled() { return true; }
+    public boolean isEnabled() {
+        return true;
+    }
 }


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 적어주세요

- [x] 프로필 이미지 변경 api
- [x] 프로필 이미지 삭제 api
- [x] userdetail에서 getMember() 메서드 추가

### 📷 스크린샷
![스크린샷 2025-01-03 204414](https://github.com/user-attachments/assets/33ee7c28-0ab2-4c16-a727-4f238f041b79)

![스크린샷 2025-01-03 212827](https://github.com/user-attachments/assets/663bfd3b-d373-411d-982f-054aeebf7902)
![스크린샷 2025-01-03 213645](https://github.com/user-attachments/assets/3e6adbd2-a4c9-4230-8566-5706ec9f6fd9)

## ☑️ 체크 리스트
> 체크  리스트를 확인해주세요
- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?


## #️⃣ 연관된 이슈
> ex) # 이슈번호

closes #20 

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 예외 처리를 이렇게 해도 괜찮을까요? / ~~부분 주의 깊게 봐주세요

사진 변경 클릭 시 이미지 변경, 사진 삭제 클릭 시 이미지 삭제
member의 id 호출을 위해 getMember() 추가