### PR TITLE
[FEAT]: 회원정보변경(닉네임, 비밀번호) API

### DIFF
--- a/src/main/java/the_t/mainproject/domain/member/application/MemberService.java
+++ b/src/main/java/the_t/mainproject/domain/member/application/MemberService.java
@@ -1,5 +1,6 @@
 package the_t.mainproject.domain.member.application;
 
+import the_t.mainproject.domain.member.dto.MemberUpdateReq;
 import the_t.mainproject.global.common.Message;
 import the_t.mainproject.global.common.SuccessResponse;
 import the_t.mainproject.global.security.UserDetailsImpl;
@@ -9,4 +10,6 @@ public interface MemberService {
     SuccessResponse<Message> modifyProfileImage(UserDetailsImpl userDetails, String profile_image);
 
     SuccessResponse<Message> deleteProfileImage(UserDetailsImpl userDetails);
+
+    SuccessResponse<Message> updateNicknamePassword(UserDetailsImpl userDetails, MemberUpdateReq memberUpdateReq);
 }

--- a/src/main/java/the_t/mainproject/domain/member/application/MemberServiceImpl.java
+++ b/src/main/java/the_t/mainproject/domain/member/application/MemberServiceImpl.java
@@ -2,10 +2,12 @@ package the_t.mainproject.domain.member.application;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import the_t.mainproject.domain.member.domain.Member;
 import the_t.mainproject.domain.member.domain.repository.MemberRepository;
+import the_t.mainproject.domain.member.dto.MemberUpdateReq;
 import the_t.mainproject.global.common.Message;
 import the_t.mainproject.global.common.SuccessResponse;
 import the_t.mainproject.global.security.UserDetailsImpl;
@@ -16,6 +18,7 @@ import the_t.mainproject.global.security.UserDetailsImpl;
 public class MemberServiceImpl implements MemberService {
 
     private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
 
     @Override
     @Transactional
@@ -42,6 +45,33 @@ public class MemberServiceImpl implements MemberService {
 
         Message message = Message.builder()
                 .message("프로필 이미지 삭제가 완료되었습니다.")
+                .build();
+
+        return SuccessResponse.of(message);
+    }
+
+    @Override
+    @Transactional
+    public SuccessResponse<Message> updateNicknamePassword(UserDetailsImpl userDetails, MemberUpdateReq memberUpdateReq) {
+        Member member = memberRepository.findById(userDetails.getMember().getId())
+                .orElseThrow(() -> new BadCredentialsException("잘못된 토큰 입력입니다."));
+
+        // 닉네임 수정
+        if(memberUpdateReq.getNickname() != null && !memberUpdateReq.getNickname().trim().isEmpty()) {
+            member.updateNickname(memberUpdateReq.getNickname());
+        }
+
+        // 비밀번호 수정
+        if(memberUpdateReq.getNewPassword() != null && !memberUpdateReq.getNewPassword().trim().isEmpty()) {
+            if(!memberUpdateReq.getNewPassword().equals(memberUpdateReq.getConfirmPassword())) {
+                throw new IllegalArgumentException("비밀번호가 일치하지 않습니다");
+            }
+
+            member.updatePassword(passwordEncoder.encode(memberUpdateReq.getNewPassword()));
+        }
+
+        Message message = Message.builder()
+                .message("회원 정보가 변경되었습니다.")
                 .build();
 
         return SuccessResponse.of(message);

--- a/src/main/java/the_t/mainproject/domain/member/domain/Member.java
+++ b/src/main/java/the_t/mainproject/domain/member/domain/Member.java
@@ -38,6 +38,10 @@ public class Member extends BaseEntity {
         this.profileImage = profileImage;
     }
 
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
     public void updatePassword(String password) {
         this.password = password;
     }

--- a/src/main/java/the_t/mainproject/domain/member/dto/MemberUpdateReq.java
+++ b/src/main/java/the_t/mainproject/domain/member/dto/MemberUpdateReq.java
@@ -1,0 +1,20 @@
+package the_t.mainproject.domain.member.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Pattern;
+import lombok.Data;
+
+@Data
+public class MemberUpdateReq {
+
+    @Schema(type = "String", example = "서버핑", description = "변경할 닉네임을 입력하세요.")
+    private String nickname;
+
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\-={}\\[\\]|:;\"'<>,.?/~`])[A-Za-z\\d!@#$%^&*()_+\\-={}\\[\\]|:;\"'<>,.?/~`]*$")
+    @Schema(type = "String", example = "password1!", description = "변경할 비밀번호를 입력해주세요")
+    private String newPassword;
+
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\-={}\\[\\]|:;\"'<>,.?/~`])[A-Za-z\\d!@#$%^&*()_+\\-={}\\[\\]|:;\"'<>,.?/~`]*$")
+    @Schema(type = "String", example = "password1!", description = "비밀번호를 재입력해주세요")
+    private String confirmPassword;
+}

--- a/src/main/java/the_t/mainproject/domain/member/presentation/MemberController.java
+++ b/src/main/java/the_t/mainproject/domain/member/presentation/MemberController.java
@@ -4,11 +4,9 @@ import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import the_t.mainproject.domain.member.application.MemberServiceImpl;
+import the_t.mainproject.domain.member.dto.MemberUpdateReq;
 import the_t.mainproject.global.common.Message;
 import the_t.mainproject.global.common.SuccessResponse;
 import the_t.mainproject.global.security.UserDetailsImpl;
@@ -30,5 +28,12 @@ public class MemberController {
     @DeleteMapping("/image")
     public ResponseEntity<SuccessResponse<Message>> deleteProfileImage(@AuthenticationPrincipal UserDetailsImpl member) {
         return ResponseEntity.ok(memberService.deleteProfileImage(member));
+    }
+
+    @Operation(summary = "회원정보 수정 (닉네임, 비밀번호)")
+    @PutMapping("/update")
+    public ResponseEntity<SuccessResponse<Message>> updateNicknamePassword(@AuthenticationPrincipal UserDetailsImpl member,
+                                                                           @RequestBody MemberUpdateReq memberUpdateReq) {
+        return ResponseEntity.ok(memberService.updateNicknamePassword(member, memberUpdateReq));
     }
 }

--- a/src/main/java/the_t/mainproject/domain/post/application/PostServiceImpl.java
+++ b/src/main/java/the_t/mainproject/domain/post/application/PostServiceImpl.java
@@ -35,6 +35,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Service
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class PostServiceImpl implements PostService {
     private final PostRepository postRepository;
@@ -143,7 +144,6 @@ public class PostServiceImpl implements PostService {
     }
 
     @Override
-    @Transactional(readOnly = true)
     public SuccessResponse<PostDetailRes> getPost(Long postId) {
         // post 찾기
         Post post = postRepository.findById(postId)
@@ -219,7 +219,6 @@ public class PostServiceImpl implements PostService {
     }
 
     @Override
-    @Transactional(readOnly = true)
     public SuccessResponse<PageResponse<PostListRes>> getMyPost(int page, int size, String sortBy,
                                                                 UserDetailsImpl userDetails) {
         //dafault 설정(DATE_DESC)으로 초기화
@@ -259,7 +258,6 @@ public class PostServiceImpl implements PostService {
     }
 
     @Override
-    @Transactional(readOnly = true)
     public SuccessResponse<PageResponse<PostListRes>> getMyLikedPost(int page, int size, String sortBy, UserDetailsImpl userDetails) {
         // 기본 정렬 설정 (DATE_DESC)
         Pageable pageRequest = PageRequest.of(page, size, Sort.by(Sort.Order.desc("createdDate")));


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 적어주세요

- [x] 회원정보 변경(닉네임, 비밀번호) api

### 📷 스크린샷
원본 db
![스크린샷 2025-01-04 205719](https://github.com/user-attachments/assets/9c23808a-2e6a-4aba-a574-d1df6b4af3e8)
수정 후 db
![스크린샷 2025-01-04 205817](https://github.com/user-attachments/assets/5f2e3372-df63-4082-a30c-f0870a41b693)

닉네임 변경
![image](https://github.com/user-attachments/assets/c0b91ea3-2950-4da6-b2d0-e0f5ad6ef327)

비밀번호 변경
실패
![스크린샷 2025-01-04 205759](https://github.com/user-attachments/assets/615ab242-b681-4fba-a0d9-9d9785ab2114)
성공
![스크린샷 2025-01-04 205807](https://github.com/user-attachments/assets/c4392683-6175-4248-8073-666af5ed792e)


## ☑️ 체크 리스트
> 체크  리스트를 확인해주세요
- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?


## #️⃣ 연관된 이슈
> ex) # 이슈번호

closes #23 

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 예외 처리를 이렇게 해도 괜찮을까요? / ~~부분 주의 깊게 봐주세요

회원정보 변경 api입니다. 닉네임만 변경 시, 비밀번호만 변경 시, 둘다 변경 시 모두 가능하며 하나만 변경하고자 할 때는 변경치 않는 내용의 body를 빈 문자열로 request하면 됩니다.