### PR TITLE
[FEAT] 키워드 검색 API 구현 및 삭제 API 수정

### DIFF
--- a/src/main/java/the_t/mainproject/domain/comment/domain/repository/CommentRepository.java
+++ b/src/main/java/the_t/mainproject/domain/comment/domain/repository/CommentRepository.java
@@ -19,4 +19,6 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     List<Comment> findByParentComment(Comment parentComment);
 
     List<Comment> findByPost(Post post);
+
+    void deleteAllByPostId(Long postId);
 }

--- a/src/main/java/the_t/mainproject/domain/liked/domain/repository/LikedRepository.java
+++ b/src/main/java/the_t/mainproject/domain/liked/domain/repository/LikedRepository.java
@@ -17,4 +17,6 @@ public interface LikedRepository extends JpaRepository<Liked, Long> {
     Page<Liked> findByMemberId(Long id, Pageable pageRequest);
 
     List<Liked> findAllByMember(Member member);
+
+    void deleteAllByPostId(Long postId);
 }

--- a/src/main/java/the_t/mainproject/domain/post/application/PostService.java
+++ b/src/main/java/the_t/mainproject/domain/post/application/PostService.java
@@ -10,6 +10,8 @@ import the_t.mainproject.global.common.PageResponse;
 import the_t.mainproject.global.common.SuccessResponse;
 import the_t.mainproject.global.security.UserDetailsImpl;
 
+import java.util.List;
+
 public interface PostService {
     SuccessResponse<Message> createPost(PostReq request, MultipartFile image, UserDetailsImpl userDetails);
     SuccessResponse<Message> updatePost(Long postId, PostReq postReq, MultipartFile image, UserDetailsImpl userDetails);
@@ -22,4 +24,5 @@ public interface PostService {
     SuccessResponse<PageResponse<PostListRes>> getMyLikedPost(int page, int size, String sortBy,
                                                          UserDetailsImpl userDetails);
     SuccessResponse<PageResponse<PostListRes>> getWordSearchedPost(int page, int size, String word);
+    SuccessResponse<PageResponse<PostListRes>> getKeywordSearchedPost(int page, int size, List<String> keywords);
 }

--- a/src/main/java/the_t/mainproject/domain/post/application/PostServiceImpl.java
+++ b/src/main/java/the_t/mainproject/domain/post/application/PostServiceImpl.java
@@ -245,14 +245,23 @@ public class PostServiceImpl implements PostService {
 
         // DTO로 변환
         List<PostListRes> postListRes = postPage.stream()
-                .map(post -> PostListRes.builder()
-                        .postId(post.getId())
-                        .title(post.getTitle())
-                        .thumb(post.getThumb())
-                        .likedCount(post.getLikedCount())
-                        .commentCount(post.getCommentCount())
-                        .createdDateTime(post.getCreatedDate().toString())
-                        .build())
+                .map(post -> {
+                    // 키워드 리스트 생성
+                    List<PostKeyword> postKeywordList = postKeywordRepository.findAllByPostId(post.getId());
+                    List<String> keywordList = postKeywordList.stream()
+                            .map(postKeyword -> postKeyword.getKeyword().getName())
+                            .toList();
+
+                    return PostListRes.builder()
+                            .postId(post.getId())
+                            .title(post.getTitle())
+                            .thumb(post.getThumb())
+                            .likedCount(post.getLikedCount())
+                            .commentCount(post.getCommentCount())
+                            .keywordList(keywordList.toString())
+                            .createdDateTime(post.getCreatedDate().toString())
+                            .build();
+                })
                 .toList();
 
         // PageResponse 생성
@@ -286,15 +295,25 @@ public class PostServiceImpl implements PostService {
 
         // DTO로 변환
         List<PostListRes> postListRes = likedPage.stream()
-                .map(liked -> PostListRes.builder()
-                        .postId(liked.getPost().getId())
-                        .title(liked.getPost().getTitle())
-                        .thumb(liked.getPost().getThumb())
-                        .likedCount(liked.getPost().getLikedCount())
-                        .commentCount(liked.getPost().getCommentCount())
-                        .createdDateTime(liked.getPost().getCreatedDate().toString()) // 공감 날짜
-                        .build())
+                .map(liked -> {
+                    // 키워드 리스트 생성
+                    List<PostKeyword> postKeywordList = postKeywordRepository.findAllByPostId(liked.getPost().getId());
+                    List<String> keywordList = postKeywordList.stream()
+                            .map(postKeyword -> postKeyword.getKeyword().getName())
+                            .toList();
+
+                    return PostListRes.builder()
+                            .postId(liked.getPost().getId())
+                            .title(liked.getPost().getTitle())
+                            .thumb(liked.getPost().getThumb())
+                            .likedCount(liked.getPost().getLikedCount())
+                            .commentCount(liked.getPost().getCommentCount())
+                            .keywordList(keywordList.toString())
+                            .createdDateTime(liked.getPost().getCreatedDate().toString()) // 공감 날짜
+                            .build();
+                })
                 .toList();
+
 
         // PageResponse 생성
         PageResponse<PostListRes> pageResponse = PageResponse.<PostListRes>builder()
@@ -314,14 +333,23 @@ public class PostServiceImpl implements PostService {
 
         // DTO로 변환
         List<PostListRes> postListRes = postPage.stream()
-                .map(post -> PostListRes.builder()
-                        .postId(post.getId())
-                        .title(post.getTitle())
-                        .thumb(post.getThumb())
-                        .likedCount(post.getLikedCount())
-                        .commentCount(post.getCommentCount())
-                        .createdDateTime(post.getCreatedDate().toString())
-                        .build())
+                .map(post -> {
+                    // 키워드 리스트 생성
+                    List<PostKeyword> postKeywordList = postKeywordRepository.findAllByPostId(post.getId());
+                    List<String> keywordList = postKeywordList.stream()
+                            .map(postKeyword -> postKeyword.getKeyword().getName())
+                            .toList();
+
+                    return PostListRes.builder()
+                            .postId(post.getId())
+                            .title(post.getTitle())
+                            .thumb(post.getThumb())
+                            .likedCount(post.getLikedCount())
+                            .commentCount(post.getCommentCount())
+                            .keywordList(keywordList.toString())
+                            .createdDateTime(post.getCreatedDate().toString())
+                            .build();
+                })
                 .toList();
 
         // PageResponse 생성

--- a/src/main/java/the_t/mainproject/domain/post/application/PostServiceImpl.java
+++ b/src/main/java/the_t/mainproject/domain/post/application/PostServiceImpl.java
@@ -140,12 +140,14 @@ public class PostServiceImpl implements PostService {
         if (post.getThumb() != null && !post.getThumb().isEmpty()) {
             s3Service.deleteImage(post.getThumb());
         }
-        // PostKeyword, post 삭제
+        // liked 삭제
+        likedRepository.deleteAllByPostId(postId);
+        // PostKeyword 삭제
         postKeywordRepository.deleteAllByPostId(postId);
-        postRepository.deleteById(postId);
-
         // 댓글, 대댓글 삭제
         commentRepository.deleteAllByPostId(postId);
+        // post 삭제
+        postRepository.deleteById(postId);
 
         return SuccessResponse.of(Message.builder()
                 .message("게시글 삭제가 완료됨")

--- a/src/main/java/the_t/mainproject/domain/post/application/PostServiceImpl.java
+++ b/src/main/java/the_t/mainproject/domain/post/application/PostServiceImpl.java
@@ -362,4 +362,44 @@ public class PostServiceImpl implements PostService {
 
         return SuccessResponse.of(pageResponse);
     }
+
+    @Override
+    public SuccessResponse<PageResponse<PostListRes>> getKeywordSearchedPost(int page, int size, List<String> keywords) {
+        Pageable pageRequest = PageRequest.of(page, size);
+
+        // 검색 쿼리 실행
+        Page<Post> postPage = postRepository.findByKeywords(keywords, pageRequest);
+
+        // DTO로 변환
+        List<PostListRes> postListRes = postPage.stream()
+                .map(post -> {
+                    // 키워드 리스트 생성
+                    List<PostKeyword> postKeywordList = postKeywordRepository.findAllByPostId(post.getId());
+                    List<String> keywordList = postKeywordList.stream()
+                            .map(postKeyword -> postKeyword.getKeyword().getName())
+                            .toList();
+
+                    return PostListRes.builder()
+                            .postId(post.getId())
+                            .title(post.getTitle())
+                            .thumb(post.getThumb())
+                            .likedCount(post.getLikedCount())
+                            .commentCount(post.getCommentCount())
+                            .keywordList(keywordList.toString())
+                            .createdDateTime(post.getCreatedDate().toString())
+                            .build();
+                })
+                .toList();
+
+        // PageResponse 생성
+        PageResponse<PostListRes> pageResponse = PageResponse.<PostListRes>builder()
+                .totalPage(postPage.getTotalPages())
+                .pageSize(postPage.getSize())
+                .totalElements(postPage.getTotalElements())
+                .contents(postListRes)
+                .build();
+
+        return SuccessResponse.of(pageResponse);
+    }
+
 }

--- a/src/main/java/the_t/mainproject/domain/post/domain/repository/PostRepository.java
+++ b/src/main/java/the_t/mainproject/domain/post/domain/repository/PostRepository.java
@@ -3,8 +3,8 @@ package the_t.mainproject.domain.post.domain.repository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import the_t.mainproject.domain.member.domain.Member;
 import org.springframework.data.jpa.repository.Query;
+import the_t.mainproject.domain.member.domain.Member;
 import the_t.mainproject.domain.post.domain.Post;
 
 import java.util.List;
@@ -18,4 +18,14 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     @Query(value = "SELECT * FROM post WHERE MATCH(title) AGAINST(:word IN BOOLEAN MODE)", nativeQuery = true)
     Page<Post> findByWord(String word, Pageable pageRequest);
 
+    @Query(value = """
+    SELECT p.*
+    FROM post p
+    JOIN post_keyword pk ON p.id = pk.post_id
+    JOIN keyword k ON pk.keyword_id = k.id
+    WHERE k.name IN (:keywords)
+    GROUP BY p.id
+    ORDER BY COUNT(k.id) DESC
+    """, nativeQuery = true)
+    Page<Post> findByKeywords(List<String> keywords, Pageable pageable);
 }

--- a/src/main/java/the_t/mainproject/domain/post/dto/req/PostReq.java
+++ b/src/main/java/the_t/mainproject/domain/post/dto/req/PostReq.java
@@ -6,9 +6,7 @@ import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import the_t.mainproject.domain.post.domain.VoiceType;
 
-import java.util.Arrays;
 import java.util.List;
 
 @RequiredArgsConstructor

--- a/src/main/java/the_t/mainproject/domain/post/dto/res/PostListRes.java
+++ b/src/main/java/the_t/mainproject/domain/post/dto/res/PostListRes.java
@@ -27,6 +27,9 @@ public class PostListRes {
     @Schema(type = "Integer", example = "1", description = "게시글 댓글 개수")
     public Integer commentCount;
 
+    @Schema(type = "String", example = "[\"덕질\", \"실수\", \"고민\"]", description = "키워드 3개")
+    public String keywordList;
+
     @Schema(type = "String", example = "2024-12-31 02:21:11.821104", description = "작성일시")
     public String createdDateTime;
 }

--- a/src/main/java/the_t/mainproject/domain/post/presentation/PostController.java
+++ b/src/main/java/the_t/mainproject/domain/post/presentation/PostController.java
@@ -19,6 +19,8 @@ import the_t.mainproject.global.common.PageResponse;
 import the_t.mainproject.global.common.SuccessResponse;
 import the_t.mainproject.global.security.UserDetailsImpl;
 
+import java.util.List;
+
 
 @RestController
 @RequestMapping("/post")
@@ -111,5 +113,14 @@ public class PostController {
             @Parameter(description = "한 페이지의 개수") @RequestParam(defaultValue = "15") int size,
             @Parameter(description = "검색 키워드") String word) {
         return ResponseEntity.ok(postService.getWordSearchedPost(page, size, word));
+    }
+
+    @Operation(summary = "키워드로 게시글 검색 (페이지네이션)")
+    @GetMapping("/search/keyword")
+    public ResponseEntity<SuccessResponse<PageResponse<PostListRes>>> getKeywordSearchedPost(
+            @Parameter(description = "현재 페이지의 번호 (0부터 시작)") @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "한 페이지의 개수") @RequestParam(defaultValue = "15") int size,
+            @Parameter(description = "검색 키워드 목록") @RequestParam List<String> keywords) {
+        return ResponseEntity.ok(postService.getKeywordSearchedPost(page, size, keywords));
     }
 }

--- a/src/main/java/the_t/mainproject/domain/post/presentation/PostController.java
+++ b/src/main/java/the_t/mainproject/domain/post/presentation/PostController.java
@@ -120,7 +120,7 @@ public class PostController {
     public ResponseEntity<SuccessResponse<PageResponse<PostListRes>>> getKeywordSearchedPost(
             @Parameter(description = "현재 페이지의 번호 (0부터 시작)") @RequestParam(defaultValue = "0") int page,
             @Parameter(description = "한 페이지의 개수") @RequestParam(defaultValue = "15") int size,
-            @Parameter(description = "검색 키워드 목록") @RequestParam List<String> keywords) {
+            @Parameter(description = "검색 키워드 목록 (comma로 구분할 것) ex)덕질,고민") @RequestParam List<String> keywords) {
         return ResponseEntity.ok(postService.getKeywordSearchedPost(page, size, keywords));
     }
 }

--- a/src/main/java/the_t/mainproject/global/config/SwaggerConfig.java
+++ b/src/main/java/the_t/mainproject/global/config/SwaggerConfig.java
@@ -18,6 +18,6 @@ public class SwaggerConfig {
     private Info apiInfo() {
         return new Info()
                 .title("스필더티 API")
-                .version("1.0.2");
+                .version("2.1.7");
     }
 }


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 적어주세요

- [x] 키워드 검색 API
- [x] 게시글 리스트 반환 시 키워드도 함께 반환
- [x] 게시글 삭제 시 댓글도 함께 삭제하도록 수정

### 📷 스크린샷
현재 게시글이 존재하지 않는 키워드('서운함')로 검색 시
![image](https://github.com/user-attachments/assets/a53dd4a4-1339-4739-94fb-43ce1e679b0f)
키워드 1개('덕질')로 검색 시
![image](https://github.com/user-attachments/assets/50732b1b-eaa3-4fa7-bd65-018d77045903)
키워드 2개('우정,고민')으로 검색 시
![image](https://github.com/user-attachments/assets/83430449-dcba-4d90-90d1-62894cb99622)



## ☑️ 체크 리스트
> 체크  리스트를 확인해주세요
- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?


## #️⃣ 연관된 이슈
> ex) # 이슈번호
#10 

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 예외 처리를 이렇게 해도 괜찮을까요? / ~~부분 주의 깊게 봐주세요

스크린샷 두번째 사진 보시면 키워드 여러 개로 검색 시 여러개에 부합하는 항목이 위에 나오고, 한개에 부합하는 항목이 아래 나옵니다. 부합하는 개수가 똑같은 항목끼리는 id순으로 정렬됩니다.