### PR TITLE
[REFACTOR]: 댓글 response 및 차단 식별자 수정

### DIFF
--- a/src/main/java/the_t/mainproject/domain/block/application/BlockService.java
+++ b/src/main/java/the_t/mainproject/domain/block/application/BlockService.java
@@ -19,11 +19,11 @@ public class BlockService {
     private final MemberRepository memberRepository;
 
     @Transactional
-    public SuccessResponse<Message> blockMember(UserDetailsImpl userDetails, String blockedEmail) {
-        Member blocker = memberRepository.findByEmail(userDetails.getUsername())
+    public SuccessResponse<Message> blockMember(UserDetailsImpl userDetails, Long blockedId) {
+        Member blocker = memberRepository.findById(userDetails.getMember().getId())
                 .orElseThrow(() -> new IllegalArgumentException("차단자 정보가 없습니다."));
 
-        Member blocked = memberRepository.findByEmail(blockedEmail)
+        Member blocked = memberRepository.findById(blockedId)
                 .orElseThrow(() -> new IllegalArgumentException("차단하고자 하는 멤버가 없습니다."));
 
         if(blockRepository.existsByBlockerAndBlocked(blocker, blocked)) {

--- a/src/main/java/the_t/mainproject/domain/block/presentation/BlockController.java
+++ b/src/main/java/the_t/mainproject/domain/block/presentation/BlockController.java
@@ -20,7 +20,7 @@ public class BlockController {
     @Operation(summary = "사용자 차단")
     @PostMapping("/blocked")
     public ResponseEntity<SuccessResponse<Message>> blockMember(@AuthenticationPrincipal UserDetailsImpl userDetails,
-                                                                @RequestParam(value = "email") String blockedEmail) {
-        return ResponseEntity.ok(blockService.blockMember(userDetails, blockedEmail));
+                                                                @RequestParam(value = "memberId") Long blockedId) {
+        return ResponseEntity.ok(blockService.blockMember(userDetails, blockedId));
     }
 }

--- a/src/main/java/the_t/mainproject/domain/comment/application/CommentService.java
+++ b/src/main/java/the_t/mainproject/domain/comment/application/CommentService.java
@@ -7,6 +7,7 @@ import the_t.mainproject.domain.comment.domain.Comment;
 import the_t.mainproject.domain.comment.domain.repository.CommentRepository;
 import the_t.mainproject.domain.comment.dto.response.CommentListRes;
 import the_t.mainproject.domain.comment.dto.response.ReplyListRes;
+import the_t.mainproject.domain.member.domain.Member;
 import the_t.mainproject.domain.post.domain.Post;
 import the_t.mainproject.domain.post.domain.repository.PostRepository;
 import the_t.mainproject.global.common.Message;
@@ -23,7 +24,7 @@ public class CommentService {
     private final CommentRepository commentRepository;
     private final PostRepository postRepository;
 
-    public SuccessResponse<List<CommentListRes>> getCommentList(Long postId) {
+    public SuccessResponse<List<CommentListRes>> getCommentList(Long postId, Long memberId) {
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 게시글이 없습니다. " + postId));
 
@@ -43,18 +44,19 @@ public class CommentService {
         List<CommentListRes> commentDetails = new ArrayList<>();
 
         for(Comment comment : topLikedCommentList) {
-            CommentListRes commentListRes = mappingCommentListRes(comment);
+            CommentListRes commentListRes = mappingCommentListRes(comment, memberId);
             commentDetails.add(commentListRes);
         }
 
         for(Comment comment : sortedCommentList) {
-            CommentListRes commentListRes = mappingCommentListRes(comment);
+            CommentListRes commentListRes = mappingCommentListRes(comment, memberId);
             commentDetails.add(commentListRes);
         }
 
         for(Comment reply : replyList) {
             ReplyListRes replyListRes = ReplyListRes.builder()
                     .commentId(reply.getId())
+                    .mine(memberId != null && memberId.equals(reply.getMember().getId()))
                     .parentCommentId(reply.getParentComment().getId())
                     .profileImage(reply.getMember().getProfileImage())
                     .nickname(reply.getMember().getNickname())
@@ -72,9 +74,10 @@ public class CommentService {
         return SuccessResponse.of(commentDetails);
     }
 
-    private CommentListRes mappingCommentListRes(Comment comment) {
+    private CommentListRes mappingCommentListRes(Comment comment, Long memberId) {
         return CommentListRes.builder()
                 .commentId(comment.getId())
+                .mine(memberId != null && memberId.equals(comment.getMember().getId()))
                 .profileImage(comment.getMember().getProfileImage())
                 .nickname(comment.getMember().getNickname())
                 .content(comment.getContent())

--- a/src/main/java/the_t/mainproject/domain/comment/dto/response/CommentListRes.java
+++ b/src/main/java/the_t/mainproject/domain/comment/dto/response/CommentListRes.java
@@ -17,6 +17,9 @@ public class CommentListRes {
     @Schema(type = "Long", example = "1", description = "댓글 아이디를 반환합니다.")
     private Long commentId;
 
+    @Schema(type = "Boolean", example = "true", description = "본인 댓글이면 true, 아니면 false를 반환합니다.")
+    private Boolean mine;
+
     @Schema(type = "String", example = "image.jpg", description = "프로필 이미지를 표시합니다.")
     private String profileImage;
 

--- a/src/main/java/the_t/mainproject/domain/comment/dto/response/ReplyListRes.java
+++ b/src/main/java/the_t/mainproject/domain/comment/dto/response/ReplyListRes.java
@@ -18,6 +18,9 @@ public class ReplyListRes {
     @Schema(type = "Long", example = "1", description = "부모 댓글의 아이디를 반환합니다.")
     private Long parentCommentId;
 
+    @Schema(type = "Boolean", example = "true", description = "본인 대댓글이면 true, 아니면 false를 반환합니다.")
+    private Boolean mine;
+
     @Schema(type = "String", example = "image.jpg", description = "프로필 이미지를 표시합니다.")
     private String profileImage;
 

--- a/src/main/java/the_t/mainproject/domain/comment/presentation/CommentController.java
+++ b/src/main/java/the_t/mainproject/domain/comment/presentation/CommentController.java
@@ -12,6 +12,7 @@ import the_t.mainproject.domain.comment.application.CreateCommentService;
 import the_t.mainproject.domain.comment.application.CreateCommentServiceFactory;
 import the_t.mainproject.domain.comment.dto.request.CreateCommentReq;
 import the_t.mainproject.domain.comment.dto.response.CommentListRes;
+import the_t.mainproject.domain.member.domain.Member;
 import the_t.mainproject.global.common.Message;
 import the_t.mainproject.global.common.SuccessResponse;
 import the_t.mainproject.global.security.UserDetailsImpl;
@@ -38,8 +39,10 @@ public class CommentController {
 
     @Operation(summary = "댓글 목록")
     @GetMapping("/posts/{postId}")
-    public ResponseEntity<SuccessResponse<List<CommentListRes>>> getComments(@PathVariable(value = "postId") Long postId) {
-        return ResponseEntity.ok(commentService.getCommentList(postId));
+    public ResponseEntity<SuccessResponse<List<CommentListRes>>> getComments(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                                             @PathVariable(value = "postId") Long postId) {
+        Long memberId = (userDetails != null) ? userDetails.getMember().getId() : null;
+        return ResponseEntity.ok(commentService.getCommentList(postId, memberId));
     }
 
     @Operation(summary = "댓글 공감")

--- a/src/main/java/the_t/mainproject/global/config/SwaggerConfig.java
+++ b/src/main/java/the_t/mainproject/global/config/SwaggerConfig.java
@@ -18,6 +18,6 @@ public class SwaggerConfig {
     private Info apiInfo() {
         return new Info()
                 .title("스필더티 API")
-                .version("2.1.7");
+                .version("2.1.8");
     }
 }


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 적어주세요

- [x] 댓글 response에 본인 댓글인 mine boolean값 추가
- [x] 차단 기능 구현 시 식별자를 id로 수정

### 📷 스크린샷
[본인 댓글이 아니거나 로그인하지 않은 경우]
![스크린샷 2025-01-16 233434](https://github.com/user-attachments/assets/63ea1902-f4c9-4f3c-b411-086932ac3881)

[본인이 작성한 댓글, 대댓글인 경우]
![스크린샷 2025-01-17 001851](https://github.com/user-attachments/assets/0414d013-b5ff-4056-93eb-d14e48e3b1db)

[사용자 차단 시 사용자 id로 차단]
![스크린샷 2025-01-17 190904](https://github.com/user-attachments/assets/bf37d3dc-e851-4f2d-ac78-5085046e3cb4)
[db 적용 확인]
![스크린샷 2025-01-17 190919](https://github.com/user-attachments/assets/dc27006b-c580-4596-8ea6-0ca4078da4d6)


## ☑️ 체크 리스트
> 체크  리스트를 확인해주세요
- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?


## #️⃣ 연관된 이슈
> ex) # 이슈번호

closes #57 

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 예외 처리를 이렇게 해도 괜찮을까요? / ~~부분 주의 깊게 봐주세요

본인 확인용 response값 추가, 차단 시 사용자 id로 식별자 구분, 배포 전 스웨거 버전 업데이트