### PR TITLE
[REFACTOR] 회원 탈퇴 로직 수정

### DIFF
--- a/src/main/java/the_t/mainproject/domain/comment/domain/Comment.java
+++ b/src/main/java/the_t/mainproject/domain/comment/domain/Comment.java
@@ -66,4 +66,8 @@ public class Comment extends BaseEntity {
     public void addReportedCount() {
         this.reportedCount++;
     }
+
+    public void subtractReportedCount() {
+        this.reportedCount--;
+    }
 }

--- a/src/main/java/the_t/mainproject/domain/commentreport/application/CommentReportService.java
+++ b/src/main/java/the_t/mainproject/domain/commentreport/application/CommentReportService.java
@@ -37,8 +37,8 @@ public class CommentReportService {
         comment.addReportedCount();
         commentReportRepository.save(commentReport);
 
-        // 일정 수 쌓였을 경우 댓글 삭제(5회 초과로 설정)
-        if(comment.getReportedCount() > 5) {
+        // 일정 수 쌓였을 경우 댓글 삭제(10회 초과로 설정)
+        if(comment.getReportedCount() > 10) {
             commentReportRepository.deleteAllByCommentId(commentId);
             commentRepository.deleteById(commentId);
         }

--- a/src/main/java/the_t/mainproject/domain/commentreport/domain/repository/CommentReportRepository.java
+++ b/src/main/java/the_t/mainproject/domain/commentreport/domain/repository/CommentReportRepository.java
@@ -2,8 +2,13 @@ package the_t.mainproject.domain.commentreport.domain.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import the_t.mainproject.domain.commentreport.domain.CommentReport;
+import the_t.mainproject.domain.member.domain.Member;
+
+import java.util.List;
 
 public interface CommentReportRepository extends JpaRepository<CommentReport, Long> {
 
     void deleteAllByCommentId(Long commentId);
+
+    List<CommentReport> findAllByMember(Member member);
 }

--- a/src/main/java/the_t/mainproject/domain/post/domain/Post.java
+++ b/src/main/java/the_t/mainproject/domain/post/domain/Post.java
@@ -29,7 +29,7 @@ public class Post extends BaseEntity {
     @Column(name = "content", columnDefinition = "TEXT")
     private String content;
 
-    @Column(name = "thumbUrl", columnDefinition = "TEXT")
+    @Column(name = "thumb_url", columnDefinition = "TEXT")
     private String thumbUrl;
 
     @Column(name = "liked_count")

--- a/src/main/java/the_t/mainproject/domain/post/domain/Post.java
+++ b/src/main/java/the_t/mainproject/domain/post/domain/Post.java
@@ -87,4 +87,7 @@ public class Post extends BaseEntity {
         this.reportedCount++;
     }
 
+    public void subtractReportedCount() {
+        this.reportedCount--;
+    }
 }

--- a/src/main/java/the_t/mainproject/domain/post/presentation/PostController.java
+++ b/src/main/java/the_t/mainproject/domain/post/presentation/PostController.java
@@ -136,5 +136,4 @@ public class PostController {
         Long memberId = authenticationService.getMemberIdFromAuthentication();
         return ResponseEntity.ok(postService.getKeywordSearchedPost(page, size, keywords, memberId));
     }
-    }
 }

--- a/src/main/java/the_t/mainproject/domain/postreport/application/PostReportService.java
+++ b/src/main/java/the_t/mainproject/domain/postreport/application/PostReportService.java
@@ -37,8 +37,8 @@ public class PostReportService {
         post.addReportedCount();
         postReportRepository.save(postReport);
 
-        // 일정 수 쌓였을 경우 댓글 삭제(5회 초과로 설정)
-        if(post.getReportedCount() > 5) {
+        // 일정 수 쌓였을 경우 댓글 삭제(10회 초과로 설정)
+        if(post.getReportedCount() > 10) {
             postReportRepository.deleteAllByPostId(postId);
             postRepository.deleteById(postId);
         }

--- a/src/main/java/the_t/mainproject/domain/postreport/domain/repository/PostReportRepository.java
+++ b/src/main/java/the_t/mainproject/domain/postreport/domain/repository/PostReportRepository.java
@@ -1,9 +1,14 @@
 package the_t.mainproject.domain.postreport.domain.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import the_t.mainproject.domain.member.domain.Member;
 import the_t.mainproject.domain.postreport.domain.PostReport;
+
+import java.util.List;
 
 public interface PostReportRepository extends JpaRepository<PostReport, Long> {
 
     void deleteAllByPostId(Long postId);
+
+    List<PostReport> findAllByMember(Member member);
 }

--- a/src/main/java/the_t/mainproject/global/config/SwaggerConfig.java
+++ b/src/main/java/the_t/mainproject/global/config/SwaggerConfig.java
@@ -18,6 +18,6 @@ public class SwaggerConfig {
     private Info apiInfo() {
         return new Info()
                 .title("스필더티 API")
-                .version("2.1.9");
+                .version("2.1.11");
     }
 }

--- a/src/main/resources/db/migration/V7__remove_image.sql
+++ b/src/main/resources/db/migration/V7__remove_image.sql
@@ -1,0 +1,6 @@
+-- image 테이블 삭제
+DROP TABLE IF EXISTS image;
+
+-- post 테이블에 thumb_url 재생성
+ALTER TABLE post
+    ADD COLUMN thumb_url TEXT NULL;


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 적어주세요

- [x] flyway 최신화
- [x] 회원 탈퇴 시 게시글, 댓글 신고 내역 삭제 추가
- [x] 게시글, 댓글 신고 누적량 수정(5 -> 10)

### 📷 스크린샷


## ☑️ 체크 리스트
> 체크  리스트를 확인해주세요
- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?


## #️⃣ 연관된 이슈
> ex) # 이슈번호

closes #72 

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 예외 처리를 이렇게 해도 괜찮을까요? / ~~부분 주의 깊게 봐주세요

1. 배포 환경을 위해 flyway 및 sql 파일 추가
2. 회원 탈퇴 시 게시글, 댓글 신고 내역 삭제 및 각 service에서 메서드 재활용
3. 신고 누적 제한량을 5에서 10으로 변경(기획 의도)